### PR TITLE
Add option to obfuscate various data points being logged

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ This year as work content change, I have no spare time to maintaining the node m
 ## Installation
 
     npm install express-bunyan-logger
-   
+
 ## Usage
 
-To use the logger: 
+To use the logger:
 
     app.use(require('express-bunyan-logger')());
 
@@ -26,7 +26,7 @@ To use the errorLogger:
 And you can also pass bunyan logger options to the logger middleware:
 
     app.use(require('express-bunyan-logger')({
-        name: 'logger', 
+        name: 'logger',
         streams: [{
             level: 'info',
             stream: process.stdout
@@ -63,7 +63,7 @@ Whether to parse _user-agent_ in logger, default is =true=.
 
 ### options.levelFn
 
-Function that translate statusCode into log level. The `meta` argument is an object consisting of all the fields gathered by bunyan-express-logger, before exclusions are applied. 
+Function that translate statusCode into log level. The `meta` argument is an object consisting of all the fields gathered by bunyan-express-logger, before exclusions are applied.
 
 ```
 function(status, err /* only will work in error logger */, meta) {
@@ -94,6 +94,17 @@ function(req, res) {
 ### options.excludes
 
 Array of string, Those fields will be excluded from meta object which passed to bunyan
+
+### options.obfuscate
+Array of strings to obfuscate.
+These strings can be in dotted notation, for instance `body.password`, and it will only replace that specific value.
+This will replace the values in log messages with a [placeholder](#optionsobfuscateplaceholder).
+
+### options.obfuscatePlaceholder
+
+Placeholder to use when obfuscating values.
+This is only applicable when there are values to obfuscate.
+Default is `[HIDDEN]`.
 
 ### options.serializers
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 var bunyan = require('bunyan'),
+    get = require('lodash.get'),
+    set = require('lodash.set'),
     useragent = require('useragent'),
     uuid = require('node-uuid'),
     util = require('util');
@@ -17,6 +19,8 @@ module.exports.errorLogger = function (opts) {
         immediate = false,
         parseUA = true,
         excludes,
+        obfuscate,
+        obfuscatePlaceholder,
         genReqId = defaultGenReqId,
         levelFn = defaultLevelFn,
         includesFn;
@@ -25,7 +29,7 @@ module.exports.errorLogger = function (opts) {
       logger = opts.logger;
     }
 
-    // default format 
+    // default format
     format = opts.format || ":remote-address :incoming :method :url HTTP/:http-version :status-code :res-headers[content-length] :referer :user-agent[family] :user-agent[major].:user-agent[minor] :user-agent[os] :response-time ms";
     delete opts.format; // don't pass it to bunyan
     (typeof format != 'function') && (format = compile(format));
@@ -45,6 +49,13 @@ module.exports.errorLogger = function (opts) {
     if (opts.excludes) {
         excludes = opts.excludes;
         delete opts.excludes;
+    }
+
+    if (opts.obfuscate) {
+        obfuscate = opts.obfuscate;
+        obfuscatePlaceholder = opts.obfuscatePlaceholder || '[HIDDEN]';
+        delete opts.obfuscate;
+        delete opts.obfuscatePlaceholder;
     }
 
     if (opts.includesFn) {
@@ -75,7 +86,7 @@ module.exports.errorLogger = function (opts) {
 
         var requestId;
 
-        if (genReqId) 
+        if (genReqId)
           requestId = genReqId(req);
 
         var childLogger = requestId !== undefined ? logger.child({req_id: requestId}) : logger;
@@ -136,8 +147,8 @@ module.exports.errorLogger = function (opts) {
                     excludes.forEach(function(ex) {
                         exs[ex] = true;
                     });
-                  
-                    for (var p in meta) 
+
+                    for (var p in meta)
                         if (!exs[p])
                           json[p] = meta[p];
                 }
@@ -151,6 +162,15 @@ module.exports.errorLogger = function (opts) {
                         json[p] = includes[p];
                     }
                 }
+            }
+
+            if (obfuscate) {
+              for(var i in obfuscate) {
+                var key = obfuscate[i];
+                if (get(json, key)) {
+                  set(json, key, obfuscatePlaceholder);
+                }
+              }
             }
 
             if (!json) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var bunyan = require('bunyan'),
-    get = require('lodash.get'),
+    has = require('lodash.has'),
     set = require('lodash.set'),
     useragent = require('useragent'),
     uuid = require('node-uuid'),
@@ -167,7 +167,7 @@ module.exports.errorLogger = function (opts) {
             if (obfuscate) {
               for(var i in obfuscate) {
                 var key = obfuscate[i];
-                if (get(json, key)) {
+                if (has(json, key)) {
                   set(json, key, obfuscatePlaceholder);
                 }
               }

--- a/index.js
+++ b/index.js
@@ -121,6 +121,7 @@ module.exports.errorLogger = function (opts) {
                 'referer': referer,
                 'user-agent': ua,
                 'body': req.body,
+                'short-body': util.inspect(req.body).substring(0, 20),
                 'http-version': httpVersion,
                 'response-time': responseTime,
                 "response-hrtime": hrtime,
@@ -174,7 +175,9 @@ module.exports.errorLogger = function (opts) {
             }
 
             // Set the short-body here in case we've modified the body in obfuscate
-            json['short-body'] = util.inspect(json.body).substring(0, 20);
+            if (json && json.body) {
+              json['short-body'] = util.inspect(json.body).substring(0, 20);
+            }
 
             if (!json) {
                 logFn.call(childLogger, format(meta));

--- a/index.js
+++ b/index.js
@@ -121,7 +121,6 @@ module.exports.errorLogger = function (opts) {
                 'referer': referer,
                 'user-agent': ua,
                 'body': req.body,
-                'short-body': util.inspect(req.body).substring(0, 20),
                 'http-version': httpVersion,
                 'response-time': responseTime,
                 "response-hrtime": hrtime,
@@ -164,6 +163,7 @@ module.exports.errorLogger = function (opts) {
                 }
             }
 
+            // obfuscate last in case we set something in our includesFn
             if (obfuscate) {
               for(var i in obfuscate) {
                 var key = obfuscate[i];
@@ -172,6 +172,9 @@ module.exports.errorLogger = function (opts) {
                 }
               }
             }
+
+            // Set the short-body here in case we've modified the body in obfuscate
+            json['short-body'] = util.inspect(json.body).substring(0, 20);
 
             if (!json) {
                 logFn.call(childLogger, format(meta));

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "bunyan": "^1.0.0",
-    "lodash.get": "^3.7.0",
+    "lodash.has": "^3.2.1",
     "lodash.set": "^3.7.4",
     "node-uuid": "^1.4.1",
     "useragent": "^2.0.9"

--- a/package.json
+++ b/package.json
@@ -18,10 +18,13 @@
   ],
   "dependencies": {
     "bunyan": "^1.0.0",
+    "lodash.get": "^3.7.0",
+    "lodash.set": "^3.7.4",
     "node-uuid": "^1.4.1",
     "useragent": "^2.0.9"
   },
   "devDependencies": {
+    "body-parser": "^1.14.2",
     "express": "4.x",
     "jshint": "~2.1.9",
     "mocha": "~1.12.0",

--- a/test/bunyan.test.js
+++ b/test/bunyan.test.js
@@ -134,7 +134,7 @@ describe('bunyan-logger', function() {
       });
   });
 
-  describe.only('test obfuscate', function() {
+  describe('test obfuscate', function() {
     var app, output,
         USERNAME = 'MY_USER',
         PASSWORD = 'MY_PASSWORD';

--- a/test/bunyan.test.js
+++ b/test/bunyan.test.js
@@ -3,6 +3,7 @@ var assert = require('assert');
 var request = require('supertest');
 var through = require('through2');
 var bunyanLogger = require('../');
+var util = require('util');
 
 
 require('buffer');
@@ -192,7 +193,11 @@ describe('bunyan-logger', function() {
             assert.equal(json['status-code'], 200);
 
             assert(json['short-body']);
-            assert.equal(json['short-body'], "{ p: '[HIDDEN]'}");
+
+            // We specifically chose a short key here to ensure our test was valid
+            // If there were multiple keys, there's a chance it won't appear
+            expected = util.inspect({p: '[HIDDEN]'}).substring(0, 20);
+            assert.equal(json['short-body'], expected);
 
             done();
           });

--- a/test/bunyan.test.js
+++ b/test/bunyan.test.js
@@ -172,6 +172,36 @@ describe('bunyan-logger', function() {
         });
     });
 
+    it('uses custom placeholder', function(done) {
+      var PLACEHOLDER = 'AAAAAA';
+
+      app.use(bunyanLogger({
+        stream: output,
+        obfuscate: ['req.body.password'],
+        obfuscatePlaceholder: PLACEHOLDER
+      }));
+
+      app.post('/', function(req, res) {
+        res.send('POST /');
+      });
+
+      request(app)
+        .post('/')
+        .send({username: USERNAME, password: PASSWORD})
+        .expect('POST /', function(err, res) {
+          var json = JSON.parse(output.content.toString());
+          assert.equal(json.name, 'express');
+          assert.equal(json.url, '/');
+          assert.equal(json['status-code'], 200);
+
+          assert(json.body);
+          assert.equal(json.body.username, USERNAME);
+          assert.equal(json.body.password, PLACEHOLDER);
+
+          done();
+        });
+    });
+
     it('obfuscates short-body', function(done) {
       app.use(bunyanLogger({
         stream: output,

--- a/test/bunyan.test.js
+++ b/test/bunyan.test.js
@@ -145,63 +145,61 @@ describe('bunyan-logger', function() {
       output = st();
     });
 
-    describe('POST', function() {
-      it('obfuscates body', function(done) {
-        app.use(bunyanLogger({
-          stream: output,
-          obfuscate: ['req.body.password']
-        }));
+    it('obfuscates body', function(done) {
+      app.use(bunyanLogger({
+        stream: output,
+        obfuscate: ['req.body.password']
+      }));
 
-        app.post('/', function(req, res) {
-          res.send('POST /');
-        });
-
-        request(app)
-          .post('/')
-          .send({username: USERNAME, password: PASSWORD})
-          .expect('POST /', function(err, res) {
-            var json = JSON.parse(output.content.toString());
-            assert.equal(json.name, 'express');
-            assert.equal(json.url, '/');
-            assert.equal(json['status-code'], 200);
-
-            assert(json.body);
-            assert.equal(json.body.username, USERNAME);
-            assert.equal(json.body.password, '[HIDDEN]');
-
-            done();
-          });
+      app.post('/', function(req, res) {
+        res.send('POST /');
       });
 
-      it('obfuscates short-body', function(done) {
-        app.use(bunyanLogger({
-          stream: output,
-          obfuscate: ['req.body.p']
-        }));
+      request(app)
+        .post('/')
+        .send({username: USERNAME, password: PASSWORD})
+        .expect('POST /', function(err, res) {
+          var json = JSON.parse(output.content.toString());
+          assert.equal(json.name, 'express');
+          assert.equal(json.url, '/');
+          assert.equal(json['status-code'], 200);
 
-        app.post('/', function(req, res) {
-          res.send('POST /');
+          assert(json.body);
+          assert.equal(json.body.username, USERNAME);
+          assert.equal(json.body.password, '[HIDDEN]');
+
+          done();
         });
+    });
 
-        request(app)
-          .post('/')
-          .send({p: 'MY_PASSWORD'})
-          .expect('POST /', function(err, res) {
-            var json = JSON.parse(output.content.toString());
-            assert.equal(json.name, 'express');
-            assert.equal(json.url, '/');
-            assert.equal(json['status-code'], 200);
+    it('obfuscates short-body', function(done) {
+      app.use(bunyanLogger({
+        stream: output,
+        obfuscate: ['req.body.p']
+      }));
 
-            assert(json['short-body']);
-
-            // We specifically chose a short key here to ensure our test was valid
-            // If there were multiple keys, there's a chance it won't appear
-            expected = util.inspect({p: '[HIDDEN]'}).substring(0, 20);
-            assert.equal(json['short-body'], expected);
-
-            done();
-          });
+      app.post('/', function(req, res) {
+        res.send('POST /');
       });
+
+      request(app)
+        .post('/')
+        .send({p: 'MY_PASSWORD'})
+        .expect('POST /', function(err, res) {
+          var json = JSON.parse(output.content.toString());
+          assert.equal(json.name, 'express');
+          assert.equal(json.url, '/');
+          assert.equal(json['status-code'], 200);
+
+          assert(json['short-body']);
+
+          // We specifically chose a short key here to ensure our test was valid
+          // If there were multiple keys, there's a chance it won't appear
+          expected = util.inspect({p: '[HIDDEN]'}).substring(0, 20);
+          assert.equal(json['short-body'], expected);
+
+          done();
+        });
     });
   });
 


### PR DESCRIPTION
This adds a new option that will obfuscate (replace) data before with `[HIDDEN]` (or a configurable value). 

The rationale behind this is to allow developers to explicitly obfuscate sensitive data such as passwords or credit card numbers (which might be in `body`) or API keys (which might be in `req-headers`). It does not remove the data in order to allow the logs to differentiate whether or not the value was provided in the request.

I used `lodash.(get|set)` to trivially access nested values via dotted notation. I also added `body-parser` as a `devDependency` in order to test POSTing values.

This is the same PR as villadora/express-bunyan-logger#34
